### PR TITLE
Remove bottle :unneeded (deprecated)

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -3,7 +3,6 @@ class Encore < Formula
   homepage "https://encore.dev"
   version "0.17.2"
   license ""
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://d2f391esomvqpi.cloudfront.net/encore-0.17.2-darwin_amd64.tar.gz"


### PR DESCRIPTION
## Problem

When running `brew upgrade` I get the following warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the encoredev/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/encoredev/homebrew-tap/Formula/encore.rb:6
```

`bottle :unneeded` was deprecated by `homebrew-core` in June 2021, and no longer has any meaning to the bottler.

## Solution

Remove `bottle :unneeded`.

### Notes

Related issues:

- https://github.com/Homebrew/brew/pull/11239
- https://github.com/hashicorp/homebrew-tap/pull/157
- [homebrew - What does 'bottle :unneeded' do? - Stack Overflow](https://stackoverflow.com/questions/45132704/what-does-bottle-unneeded-do)