### PR TITLE
Release Encore v1.9.1-test

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -1,25 +1,25 @@
 class Encore < Formula
   desc "The static analysis-powered Go framework for building backend applications"
   homepage "https://encore.dev"
-  version "1.9.1"
+  version "1.9.1-test"
   license "Mozilla Public License, version 2.0"
   head "https://github.com/encoredev/encore.git", branch: "main"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-darwin_amd64.tar.gz"
-    sha256 "9edd36838e0c08ee8a93c61238439a7bad521f6d7e8be03a81d83fac1c54215c"
+    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-darwin_amd64.tar.gz"
+    sha256 "sha1"
   end
   if OS.mac? && Hardware::CPU.arm?
-    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-darwin_arm64.tar.gz"
-    sha256 "cc4405e56b768f1bee8ab5a92779754fde4148d89bbc31cb40303a4a5aa93b4e"
+    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-darwin_arm64.tar.gz"
+    sha256 "sha12"
   end
   if OS.linux? && Hardware::CPU.intel?
-    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-linux_amd64.tar.gz"
-    sha256 "df161f28e7ea07285c7de48d35fde58de64464f1e03b07d1fadc0ac41c6ca52a"
+    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_amd64.tar.gz"
+    sha256 "sha3"
   end
   if OS.linux? && Hardware::CPU.arm?
-    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-linux_arm64.tar.gz"
-    sha256 "859ac30a3da796a4ffc744e5018a73f154c4b8dfea71cb21040d21def0aca001"
+    url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_arm64.tar.gz"
+    sha256 "sha4"
   end
 
   def install

--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -15,7 +15,7 @@ class Encore < Formula
   end
   if OS.linux? && Hardware::CPU.intel?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_amd64.tar.gz"
-    sha256 "sha3"
+    sha256 "sha333"
   end
   if OS.linux? && Hardware::CPU.arm?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_arm64.tar.gz"

--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -7,7 +7,7 @@ class Encore < Formula
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-darwin_amd64.tar.gz"
-    sha256 "sha1"
+    sha256 "sha123"
   end
   if OS.mac? && Hardware::CPU.arm?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-darwin_arm64.tar.gz"

--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -19,7 +19,7 @@ class Encore < Formula
   end
   if OS.linux? && Hardware::CPU.arm?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_arm64.tar.gz"
-    sha256 "sha4432"
+    sha256 "sha443249"
   end
 
   def install

--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -19,7 +19,7 @@ class Encore < Formula
   end
   if OS.linux? && Hardware::CPU.arm?
     url "https://d2f391esomvqpi.cloudfront.net/encore-1.9.1-test-linux_arm64.tar.gz"
-    sha256 "sha4"
+    sha256 "sha4432"
   end
 
   def install


### PR DESCRIPTION
This commit bumps the Encore version to v1.9.1-test

_This PR was created by the Encore release process automatically._