### PR TITLE
Release Encore v1.13.0

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.12.1"
+    release_version = "1.13.0"
     checksums = {
-        "darwin_arm64" => "236e3c245dca6e67fc2780aa8e14374ed7a4bd8f0e20745445309693b5667fa8",
-        "darwin_amd64" => "ed9ec112c26adc5025dc57a7fdf7b6698aa95e262069f691705c0e4a0c073be0",
-        "linux_arm64"  => "2cf697bba0adaffd6fe3a49fad886671f0699eba176aac3b5aca57e308d6bb4d",
-        "linux_amd64"  => "d0391350033b0a3f27c51af91ac1a50453deabb6dc812e15af093bf526d507b7",
+        "darwin_arm64" => "0f2fc9b717047124f233cdbbcb94dbad88272d0db842961deea8ee19aff96b42",
+        "darwin_amd64" => "8df817f432339d877b4f0f947e2ccd69697460d3fc78afcb6f46f03f3df95c4b",
+        "linux_arm64"  => "74c73e070f9c286214e03e08a53e948e84c0b13e2dd7b25831bcb09165b3b420",
+        "linux_amd64"  => "014f5e344a8a79cdbf7367697246eaccca44747911d5695ed9515fa85fbe8e5b",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.13.0

_This PR was created by the Encore release process automatically._