### PR TITLE
Release Encore v1.13.3

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.13.2"
+    release_version = "1.13.3"
     checksums = {
-        "darwin_arm64" => "2fdb7e08c7a07ef30fab3ce072b3bc6d97d437893ab4acba55834f6577857374",
-        "darwin_amd64" => "475d2ab607a932f911f36983128550965e04e023a7547c6fbf25d6558988f1fd",
-        "linux_arm64"  => "927b4dae3d0bd1bb26b625ac2cae06f2808760fee18086059dc5acc605729a6b",
-        "linux_amd64"  => "96a6c4d53132e8fd92216ff58d0140dcab40e00ec13dc33d5fa2f2d314f38d69",
+        "darwin_arm64" => "d9cf756b6d261f2305843a86ccd1c64d154d8cdc9db39b0e0c09ae7bbf6ce05c",
+        "darwin_amd64" => "fe8c8fac7218344adace1b8c85d136c2c698ff3608b5fd610f987f27a3ea0146",
+        "linux_arm64"  => "5cad231de8f083df53d5012778dc9c060bf3d3c9ee96a56983ad2d1e5287bba4",
+        "linux_amd64"  => "4e1e543595cd731409759ee481acf9783991f7edff7246f8e39526488c1bd56d",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.13.3

_This PR was created by the Encore release process automatically._