### PR TITLE
Release Encore v1.20.5

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.20.4"
+    release_version = "1.20.5"
     checksums = {
-        "darwin_arm64" => "4aca0ecbdd8f1be74c0661cb7fb6563dd0475914fd042de44dbcdb35986cfb8a",
-        "darwin_amd64" => "6000822acc9a7ba7702ea5a20303bb3bd9cd14e34e01adaeca6dea6b879193e6",
-        "linux_arm64"  => "7d7d958940bb4b65928b92444bef20c2cd726d733f932024c929eb76ff2b6301",
-        "linux_amd64"  => "a90a426923e70f16ffcf0fc36987eb7df21001ad48227c3d96e1c936b678d84c",
+        "darwin_arm64" => "3ec1be2c6988769d752949115c41a66311e88bae332ae4eeecbd6286e594f569",
+        "darwin_amd64" => "3a717ee42558469134ccf6260c937946ad1bf1a58414d5e9c821c80f632ea1d4",
+        "linux_arm64"  => "ef3dbe4067c284dee23fba41c90b690be8e11f0efbf17d092d1f0ad613e755b4",
+        "linux_amd64"  => "0d5c9d7398e9bc43f63387a5411770cee2943008be91af37ed9ee4824a651aac",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.20.5

_This PR was created by the Encore release process automatically._