### PR TITLE
Release Encore v1.22.0

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.21.2"
+    release_version = "1.22.0"
     checksums = {
-        "darwin_arm64" => "f8490f2b583118f632d630e4414dad9140790f9f031fab63c535106cae9faea4",
-        "darwin_amd64" => "e81f24061a6c61800a7b7ded29fa918222cf34a056eb47c817b22b3747c3cf59",
-        "linux_arm64"  => "baa1dd3b95d310b1a470372d1944596e887beb7f002357af15105b33892b0831",
-        "linux_amd64"  => "34727f4251b1b5478c1af3cc6f8822255a7af8ad4f1af8bf945c6583c9a3744d",
+        "darwin_arm64" => "d8d2c00ab32ba4891568676278777ba7a1696043160d7a351ea1e3f7f16020f1",
+        "darwin_amd64" => "de48acb1790720cce4667d16540427758feb915fec4e5afe8befd739fd1543f6",
+        "linux_arm64"  => "378b38bf184ea3149c41d97a186cf165bd6567911f18b77e8457dbdc4584f72c",
+        "linux_amd64"  => "b75b7f7f42e72323d82ddd764996070169b52bf6d0a91f90c54af29a19bdb8a3",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.22.0

_This PR was created by the Encore release process automatically._