### PR TITLE
Release Encore v1.22.3

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.22.1"
+    release_version = "1.22.3"
     checksums = {
-        "darwin_arm64" => "41de0e3a95c0234edfe1846ae243ea64a5114eae96efdfbaf875c31c903cb5b5",
-        "darwin_amd64" => "ebfc90506b718978a27e81abc081a0bc6d1514fee4c742ebb78cf816e4c102df",
-        "linux_arm64"  => "fcd33dcb26bddba3f476192f5c3cbdaf831ac603b8a17eae9b1df06745e83b5a",
-        "linux_amd64"  => "4ce0e174fde29de19cc458c31e2afd203f7c7c7a8d5bab50fc18918fa5b9bb15",
+        "darwin_arm64" => "89e6c08f0bd5d6a006b83ba52b960eb00b47cf66d0c8dff525030accb45662a4",
+        "darwin_amd64" => "8649c12171170694508fc20fa085f7ed2875c8d4f0a3dd0c3fa601052bb4874a",
+        "linux_arm64"  => "e4fbfed0ca019ade2adeb0f4ebe5688d844b809147a4ab7e7f547d27e380bb0d",
+        "linux_amd64"  => "68598c14de58c8298e36dbe3d49aaae611bb1b6f71a185edde07195975b607aa",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.22.3

_This PR was created by the Encore release process automatically._