### PR TITLE
Release Encore v1.23.2

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.23.0"
+    release_version = "1.23.2"
     checksums = {
-        "darwin_arm64" => "48debda2894fddbfec4ce9ed54e3dac3d5db3deee2839bc10a12adc7ae34b453",
-        "darwin_amd64" => "fe0b19296cebcbe72f3be22c004984656eb040a50f3e14a511242ed955d25e18",
-        "linux_arm64"  => "3b04fe2803e6bb56ae3860c3200873d454ecd6019b2c6a9ff0987d88fe46948b",
-        "linux_amd64"  => "b226c2e0d519c4c514a4028b4a98b05e5d204d0ebad4d3bd4e87c9e3f3f91d6f",
+        "darwin_arm64" => "5b561c3e0463c7cf465717d6ba0d41f4b99e0d3eafb4ed64958b1d497821e9b9",
+        "darwin_amd64" => "4a0be1d5c972b104c8b81aacecf0c07f24f9e69fb582ba1ca50e5be1a5a64f39",
+        "linux_arm64"  => "ddeb6d4386e9c4cde0bbe7755b5674908d4fa206c56af3bcda8952c62dd097f8",
+        "linux_amd64"  => "c31b0eaf50eda45883c9b34929a44f18c287338dd37fa74d944b3c161cd6b7fc",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.23.2

_This PR was created by the Encore release process automatically._