### PR TITLE
Release Encore v1.27.1

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.27.0"
+    release_version = "1.27.1"
     checksums = {
-        "darwin_arm64" => "53608e4dd2a69d920a70705de6d982f364b17017f1fef6a8950acccc06208bbd",
-        "darwin_amd64" => "8c89da2b1dc60c1d32d5adda88fb06a5dabe4099a2866969acad567a06ac4741",
-        "linux_arm64"  => "268f8adcf1420ddf2860723fdd4285a81f8f1315b56714ef14378e72fc2d7f39",
-        "linux_amd64"  => "2b8f356f0f97d2e80c6a17f366ec075a0ec89846b19243985086f21d4067c553",
+        "darwin_arm64" => "88d04793b7556eab94c871213ada6863d355a0ca4386f2bd4b4338be52bc5382",
+        "darwin_amd64" => "493f5f1e1229bf8e88ecdbd5cb3f8aac3af5d67abf5a20d8da1c31f42deae5f3",
+        "linux_arm64"  => "b4bde123c90c0225cfed43ec3913bff129e3628ead877301597f5b28d97e5010",
+        "linux_amd64"  => "cf14054653519d1db84966aff4e61c71437514c8806588ff0413f04d4263f329",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.27.1

_This PR was created by the Encore release process automatically._