### PR TITLE
Release Encore v1.29.0

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.28.0"
+    release_version = "1.29.0"
     checksums = {
-        "darwin_arm64" => "66871d9ec15fbd358605523a22f9646375d0112d19e4c450d0d95ec4d8e27735",
-        "darwin_amd64" => "4ef8af23ebb6db7a0374d0754a19b5e14e8948cae3dbd57d899afdca9d0d7862",
-        "linux_arm64"  => "29e85e46c60b3c568ed670caaf2087a61a585a9c6ba9b02ba47cfd5e31d6c299",
-        "linux_amd64"  => "067baf3721a1589365a8714ef9c2075a9da26222dc21dde328e92bfee92c7675",
+        "darwin_arm64" => "2eb53fc4865ca0f8057f95a3385159c1a5b8a39194a2fd72bc7e83c30b3ddf0d",
+        "darwin_amd64" => "23b4cc5f334d4098ba54992fb8d04af794a33dd529a56e0295ca43108a848008",
+        "linux_arm64"  => "4e933868537fb5d99ad743e97d64b7e9e32c6e00f6d15717b264245a3bd45d0d",
+        "linux_amd64"  => "d53d88f5e3baf737f1105fd5f35867b7188b8871b9dfce27ab87e482783da1be",
     }
 
     arch = "arm64"
@@ -27,7 +27,9 @@ class Encore < Formula
 
     def install
         libexec.install Dir["*"]
+
         bin.install_symlink Dir[libexec/"bin/*"]
+
 
         # Install bash completion
         output = Utils.safe_popen_read(bin/"encore", "completion", "bash")


### PR DESCRIPTION
This commit bumps the Encore version to v1.29.0

_This PR was created by the Encore release process automatically._