### PR TITLE
Release Encore v1.29.7

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.29.6"
+    release_version = "1.29.7"
     checksums = {
-        "darwin_arm64" => "d37ae743ceb938197cbc6c954d18aefa5f59dfda7878fa6a89815688cfcb3e1e",
-        "darwin_amd64" => "7a4f5e67a93f7b68c2212b20ceb0d489aa70c3af17c92308c11101440326abbe",
-        "linux_arm64"  => "5480296fe0ae695b833cc35a4d7be6131d1c9b92aca831c7c0d14584a4fc3590",
-        "linux_amd64"  => "2d5cd65ad98cdbbe855b4ae88b3b4febfbf393b31660a249bf41037603aad2bf",
+        "darwin_arm64" => "34b302f22cc52ac80e4586f36d4a70a42c7fd798c3cf0d3b2e291613767e45f9",
+        "darwin_amd64" => "7a33772a073ffe093201c2198ef0ed83bcedb2eb48a2b992c9643a98f396efb0",
+        "linux_arm64"  => "0bcd39ec0cac2b67136a30d1fe669b9cb1b5a9c3c0792bf2cd0b235210fd1a9c",
+        "linux_amd64"  => "2669b9abb77305b12cabc523fc719ec1af486a4ba7b45a02928c16ca2c288e1a",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.29.7

_This PR was created by the Encore release process automatically._