### PR TITLE
Release Encore v1.30.0

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.28.0"
+    release_version = "1.30.0"
     checksums = {
-        "darwin_arm64" => "66871d9ec15fbd358605523a22f9646375d0112d19e4c450d0d95ec4d8e27735",
-        "darwin_amd64" => "4ef8af23ebb6db7a0374d0754a19b5e14e8948cae3dbd57d899afdca9d0d7862",
-        "linux_arm64"  => "29e85e46c60b3c568ed670caaf2087a61a585a9c6ba9b02ba47cfd5e31d6c299",
-        "linux_amd64"  => "067baf3721a1589365a8714ef9c2075a9da26222dc21dde328e92bfee92c7675",
+        "darwin_arm64" => "cba04dacd6c1c101432b43510eae95e411e8234f86fb01bef147778a46d41c34",
+        "darwin_amd64" => "fab3fbe38c760fa24a7c53b0cb610e46159e4796c6365680388405de2fbd0f10",
+        "linux_arm64"  => "4277dd5049eddca8d47418233b96ee86692b913bdfda70c8aa1b12ef45e2d646",
+        "linux_amd64"  => "7190089c7d734fb1467bba67deaaf33f717253504bec59b14fb727dd69d4080d",
     }
 
     arch = "arm64"
@@ -27,7 +27,9 @@ class Encore < Formula
 
     def install
         libexec.install Dir["*"]
+
         bin.install_symlink Dir[libexec/"bin/*"]
+
 
         # Install bash completion
         output = Utils.safe_popen_read(bin/"encore", "completion", "bash")

--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -6,10 +6,10 @@ class Encore < Formula
 
     release_version = "1.30.0"
     checksums = {
-        "darwin_arm64" => "cba04dacd6c1c101432b43510eae95e411e8234f86fb01bef147778a46d41c34",
-        "darwin_amd64" => "fab3fbe38c760fa24a7c53b0cb610e46159e4796c6365680388405de2fbd0f10",
-        "linux_arm64"  => "4277dd5049eddca8d47418233b96ee86692b913bdfda70c8aa1b12ef45e2d646",
-        "linux_amd64"  => "7190089c7d734fb1467bba67deaaf33f717253504bec59b14fb727dd69d4080d",
+        "darwin_arm64" => "28df2dcddceac326f8870b9d2a5096ff12e89816c5cf02105784761b8b2f879a",
+        "darwin_amd64" => "e3186478337be8226410ad42d6733e3a088a8d3aab9419e3e895cc0903db8a73",
+        "linux_arm64"  => "84b822d06cada5d9052ac44f99b2e98ad56667878f85716ddf375980d7538e18",
+        "linux_amd64"  => "42b9fa8d9fbf880761d2161d3baa43102a28723f0f2db771f931172d63c5162f",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.30.0

_This PR was created by the Encore release process automatically._