### PR TITLE
Release Encore v1.33.2

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.33.1"
+    release_version = "1.33.2"
     checksums = {
-        "darwin_arm64" => "703a39e8506e5e09c63fad764f6eb49ae58e4e1bd903ab4ce2d8739bb201bae9",
-        "darwin_amd64" => "47b227bdb17a5fc6407b397ac2fde5ee335bec6efdf2ecafe93787a045557d4d",
-        "linux_arm64"  => "5a9969d56c5b0b830284af60be315bb22d156e2529b5b7d88d68deaff182b624",
-        "linux_amd64"  => "f51a87d007a1dc8c6017d11cb0400a1c8bb34214891bd3c501cee9d400dd1b82",
+        "darwin_arm64" => "3b6571114ee83d4bc88b90849da3d03ab131f21ddf214997c2d85d99d6487481",
+        "darwin_amd64" => "1573f875b72d3a66e53b4f8d070054cc37e1e2e90c537c2c0bfc93486a134d0a",
+        "linux_arm64"  => "af37b060787a6bf56b42021fdaefd654d265facea83c1c4cd358ed8c87d977aa",
+        "linux_amd64"  => "f354bb0b2eee5186503402d0958aa698ade28578566381b5b8b7730295f9c56c",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.33.2

_This PR was created by the Encore release process automatically._