### PR TITLE
Release Encore v1.33.5

### DIFF
--- a/Formula/encore.rb
+++ b/Formula/encore.rb
@@ -4,12 +4,12 @@ class Encore < Formula
     license "Mozilla Public License, version 2.0"
     head "https://github.com/encoredev/encore.git", branch: "main"
 
-    release_version = "1.31.2"
+    release_version = "1.33.5"
     checksums = {
-        "darwin_arm64" => "a120b5625ac33eba486537f2721435120cf29b9f82868aad8ab1ea0305f7cf43",
-        "darwin_amd64" => "935428aec4408af3596cb0250566f089273b66f57ff6000228e03b2f6770d048",
-        "linux_arm64"  => "9327329621905e56fcdc4bdb42efb3e362c1691710b7d5ddef03e2690a46690b",
-        "linux_amd64"  => "32d6a999f5ee53d0efea925d9f16a07e8f6e85e58292a2730aa224422b5449c9",
+        "darwin_arm64" => "e52039bcc360f5ff39e9393cd9ba204e25edc8aa09288422c6ea74f8444657b3",
+        "darwin_amd64" => "fb7d9f0e16c5b1c2ccf0206173ca2874c6d4d1839118144d570d65f850b3c91a",
+        "linux_arm64"  => "a621449db2fdd841514bcf310fd8b7f4f58681807ecd69d465bbdb06266393ef",
+        "linux_amd64"  => "82be00db8091e7819fa9f94aaf7e8cfb758b6ff2c08a7b03c691813161a7c804",
     }
 
     arch = "arm64"


### PR DESCRIPTION
This commit bumps the Encore version to v1.33.5

_This PR was created by the Encore release process automatically._